### PR TITLE
Simplify homepage hero content

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     min-height: 92vh;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     overflow: hidden;
     border-bottom: 1px solid var(--line);
   }
@@ -29,7 +29,7 @@
     opacity: 0.9;
   }
   canvas#scope { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0.9; }
-  .hero-inner { position: relative; z-index: 2; padding: clamp(64px, 10vw, 40px) clamp(20px, 4vw, 56px) 40px; }
+  .hero-inner { position: relative; z-index: 2; padding: clamp(100px, 14vw, 160px) clamp(20px, 4vw, 56px) 40px; }
   .hero-eyebrow {
     font-family: 'Plex Mono', monospace; font-size: 12.5px; letter-spacing: 0.16em;
     text-transform: uppercase; color: var(--trace); margin-bottom: 18px;

--- a/index.html
+++ b/index.html
@@ -37,11 +37,6 @@
   .hero-eyebrow b { color: var(--accent); font-weight: 600; }
   h1.name { font-size: clamp(3.2rem, 11vw, 8.4rem); line-height: 0.86; margin: 0 0 22px; }
   h1.name .last { color: var(--accent); }
-  .hero-tagline {
-    font-family: 'Plex', sans-serif; font-weight: 400; font-size: clamp(1.05rem, 2vw, 1.35rem);
-    color: var(--ink-dim); max-width: 46ch; margin-bottom: 34px;
-  }
-  .hero-tagline em { font-style: italic; color: var(--ink); }
   .readout {
     display: flex; flex-wrap: wrap; gap: 10px 28px;
     font-family: 'Plex Mono', monospace; font-size: 12.5px; color: var(--ink-dim); letter-spacing: 0.02em;
@@ -85,7 +80,6 @@
 <body>
 
 <nav class="nav">
-  <a class="nav-id" href="index.html">AMI<span>_</span>CTRL</a>
   <ul class="nav-links">
     <li><a href="index.html" aria-current="page">Home</a></li>
     <li><a href="resume.html">Resume</a></li>
@@ -100,13 +94,12 @@
   <div class="scope-grid"></div>
   <canvas id="scope"></canvas>
   <div class="hero-inner wrap">
-    <div class="hero-eyebrow"><b>●</b>&nbsp; Electrical Architecture / Hydrogen Systems / Control Command</div>
+    <div class="hero-eyebrow"><b>●</b>&nbsp; Electrical &amp; Mechanical Systems / Control Command / Model Based System Engineering</div>
     <h1 class="name">ABDEL<br>MALEK<br><span class="last">IMOKRANE</span></h1>
-    <p class="hero-tagline">I architect and control the systems that turn hydrogen into propulsion — <em>from electrical safety architecture to the control laws running in the loop.</em></p>
     <div class="readout">
-      <span>LOC <b>Vanves, FR</b></span>
+      <span>LOC <b>Hauts-de-Seine, FR</b></span>
       <span>ROLE <b>Senior Embedded Systems Engineer</b></span>
-      <span>NOW <b>R&amp;D Expleo — Hydrogen Propulsion Systems</b></span>
+      <span>NOW <b>Expleo France</b></span>
       <span class="live"><span class="live-dot"></span>OPEN TO NEW SIGNAL</span>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
   .route canvas { width: 100%; height: 46px; display: block; margin: 16px 0 14px; }
   .route h3 { font-size: 1.28rem; margin: 0 0 8px; text-transform: none; letter-spacing: 0; }
   .route p { color: var(--ink-dim); font-size: 0.92rem; margin: 0; flex: 1; }
-  .route .route-meta { font-family: 'Plex Mono', monospace; font-size: 10.5px; color: var(--trace); letter-spacing: 0.05em; text-transform: uppercase; margin-top: 14px; }
+  .route .route-meta { font-family: 'Plex Mono', monospace; font-size: 10.5px; color: var(--trace); letter-spacing: 0.05em; text-transform: uppercase; margin-top: auto; padding-top: 14px; }
 
   @media (max-width: 880px) { .routes { grid-template-columns: repeat(2, 1fr); } }
   @media (max-width: 520px) { .routes { grid-template-columns: 1fr; } }
@@ -141,7 +141,6 @@
           <div class="route-ch">CH.04 <span class="route-arrow">↗</span></div>
           <canvas class="d-canvas" data-kind="square"></canvas>
           <h3>Contact</h3>
-          <p>Direct line, no form to fill — a reply usually beats a submission.</p>
           <div class="route-meta">Email</div>
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
   <div class="scope-grid"></div>
   <canvas id="scope"></canvas>
   <div class="hero-inner wrap">
-    <div class="hero-eyebrow"><b>●</b>&nbsp; Electrical &amp; Mechanical Systems / Control Command / Model Based System Engineering</div>
+    <div class="hero-eyebrow"><b>●</b>&nbsp; Electrical &amp; Mechanical Systems / Control Command<br>Model Based System Engineering / Model Based Design</div>
     <h1 class="name">ABDEL<br>MALEK<br><span class="last">IMOKRANE</span></h1>
     <div class="readout">
       <span>LOC <b>Hauts-de-Seine, FR</b></span>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
           <canvas class="d-canvas" data-kind="square"></canvas>
           <h3>Contact</h3>
           <p>Direct line, no form to fill — a reply usually beats a submission.</p>
-          <div class="route-meta">malek.imokrane@gmail.com</div>
+          <div class="route-meta">Email</div>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Why this PR exists

Same situation as #26: PR #28 was stacked on #27 (base: \`feature/norway-gallery\`). #27 merged into \`master\` first; #28 merged into \`feature/norway-gallery\` afterward, so its commits never made it into \`master\`. This PR closes that gap — same 5 commits that were in #28, no new changes.

## Summary
Five small content/layout changes to the homepage hero:

1. Removed the "AMI_CTRL" logo/home-link from the top-left of the nav.
2. "NOW" simplified to "Expleo France".
3. "LOC" now shows department instead of city: "Hauts-de-Seine, FR".
4. Eyebrow line split across two lines to avoid mid-phrase wrapping: "Electrical & Mechanical Systems / Control Command" / "Model Based System Engineering / Model Based Design".
5. Removed the descriptive tagline paragraph under the name, and fixed the resulting excess whitespace above the eyebrow (hero was vertically centering a now-shorter content block in a 92vh box; also fixed a broken `clamp()` that always resolved to a fixed value regardless of viewport).
6. Contact tile: removed the visible email address and description line, keeping the mailto link itself functional.

## Test plan
Same verification as #28 — every change checked live in-browser, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)